### PR TITLE
searching npm for crypto-native yields no results

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-crypto-native
+native-crypto
 ===
 
 The intent of this is browserifable crypt, which uses the node module on the server, the subtle crypto api if available and the browserify-crypto if not.


### PR DESCRIPTION
Since there are no installation instructions in the readme I copied the projectname from the readme and searched on NPM without results.

Then it took me a while to realize that the name is native-crypto not crypto-native.